### PR TITLE
Multi-Display Order and Dual Row Layout

### DIFF
--- a/Spaceman/Helpers/IconCreator.swift
+++ b/Spaceman/Helpers/IconCreator.swift
@@ -13,8 +13,6 @@ class IconCreator {
     @AppStorage("layoutMode") private var layoutMode = LayoutMode.medium
     @AppStorage("displayStyle") private var displayStyle = DisplayStyle.numbersAndRects
     @AppStorage("hideInactiveSpaces") private var hideInactiveSpaces = false
-    @AppStorage("dualRows") private var dualRows = false
-    @AppStorage("dualRowsGap") private var dualRowsGap: Int = 1
     
     private let leftMargin = CGFloat(7)  /* FIXME determine actual left margin */
     private var displayCount = 1
@@ -70,7 +68,7 @@ class IconCreator {
         }
         
         let iconsWithDisplayProperties = getIconsWithDisplayProps(icons: icons, spaces: spaces)
-        if dualRows && layoutMode == .compact {
+        if layoutMode == .dualRows {
             return mergeIconsTwoRows(iconsWithDisplayProperties)
         } else {
             return mergeIcons(iconsWithDisplayProperties)
@@ -285,7 +283,7 @@ class IconCreator {
         }
 
         let totalWidth = columns.reduce(CGFloat(0)) { $0 + $1.width + $1.gapAfter }
-        let gap = CGFloat(max(0, min(dualRowsGap, 3)))
+        let gap = CGFloat(sizes.GAP_HEIGHT_DUALROWS)
         let imageHeight = iconSize.height * 2 + gap
         let image = NSImage(size: NSSize(width: totalWidth, height: imageHeight))
 

--- a/Spaceman/Helpers/SpaceSwitcher.swift
+++ b/Spaceman/Helpers/SpaceSwitcher.swift
@@ -43,10 +43,13 @@ class SpaceSwitcher {
         }
     }
     
-    public func switchUsingLocation(iconWidths: [IconWidth], horizontal: CGFloat, onError: () -> Void) {
+    public func switchUsingLocation(iconWidths: [IconWidth], point: CGPoint, onError: () -> Void) {
         var index: Int = 0
         for i in 0 ..< iconWidths.count {
-            if horizontal >= iconWidths[i].left && horizontal < iconWidths[i].right {
+            let hitX = point.x >= iconWidths[i].left && point.x < iconWidths[i].right
+            let hasY = iconWidths[i].top != 0 || iconWidths[i].bottom != 0
+            let hitY = hasY ? (point.y >= iconWidths[i].top && point.y < iconWidths[i].bottom) : true
+            if hitX && hitY {
                 index = iconWidths[i].index
                 break
             }

--- a/Spaceman/Model/GuiSize.swift
+++ b/Spaceman/Model/GuiSize.swift
@@ -10,6 +10,7 @@ import Foundation
 struct GuiSize {
     var GAP_WIDTH_SPACES: Int!
     var GAP_WIDTH_DISPLAYS: Int!
+    var GAP_HEIGHT_DUALROWS: Int!
     var ICON_WIDTH_SMALL: Int!
     var ICON_WIDTH_LARGE: Int!
     var ICON_WIDTH_XLARGE: Int!

--- a/Spaceman/Model/IconWidth.swift
+++ b/Spaceman/Model/IconWidth.swift
@@ -10,5 +10,9 @@ import Foundation
 struct IconWidth: Codable {
     let left: CGFloat
     let right: CGFloat
+    // For dual-row layout, use top/bottom to enable vertical hit testing (0 means single row)
+    var top: CGFloat = 0
+    var bottom: CGFloat = 0
+    // Positive: space number; Negative: full-screen pseudo index (-1, -2)
     let index: Int
 }

--- a/Spaceman/Model/LayoutMode.swift
+++ b/Spaceman/Model/LayoutMode.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum LayoutMode: Int {
-    case compact, medium, large
+    case compact, medium, large, dualRows
 }
 
 // Display arrangement preferences (shared by UI and sorting)
-enum DisplaySortPriority: Int { case horizontal, vertical }
-enum HorizontalSortOrder: Int { case leftToRight, rightToLeft }
-enum VerticalSortOrder: Int { case topToBottom, bottomToTop }
+enum DisplayOrderPriority: Int { case horizontal, vertical }
+enum HorizontalDirection: Int { case leftToRight, rightToLeft }
+enum VerticalDirection: Int { case topToBottom, bottomToTop }

--- a/Spaceman/Model/LayoutMode.swift
+++ b/Spaceman/Model/LayoutMode.swift
@@ -15,3 +15,6 @@ enum LayoutMode: Int {
 enum DisplayOrderPriority: Int { case horizontal, vertical }
 enum HorizontalDirection: Int { case leftToRight, rightToLeft }
 enum VerticalDirection: Int { case topToBottom, bottomToTop }
+
+// Dual-row fill order (visual ordering of spaces in dual-row layout)
+enum DualRowFillOrder: Int { case columnMajor, rowMajor }

--- a/Spaceman/Model/LayoutMode.swift
+++ b/Spaceman/Model/LayoutMode.swift
@@ -10,3 +10,8 @@ import Foundation
 enum LayoutMode: Int {
     case compact, medium, large
 }
+
+// Display arrangement preferences (shared by UI and sorting)
+enum DisplaySortPriority: Int { case horizontal, vertical }
+enum HorizontalSortOrder: Int { case leftToRight, rightToLeft }
+enum VerticalSortOrder: Int { case topToBottom, bottomToTop }

--- a/Spaceman/Model/SpaceNameInfo.swift
+++ b/Spaceman/Model/SpaceNameInfo.swift
@@ -13,4 +13,6 @@ struct SpaceNameInfo: Hashable, Codable {
     let spaceByDesktopID: String
     // Current display index after applying user display ordering (1..D). Optional for backward compatibility.
     var currentDisplayIndex: Int? = nil
+    // Current global order in status bar/menu (1..N) after applying display sorting.
+    var currentOrder: Int? = nil
 }

--- a/Spaceman/Model/SpaceNameInfo.swift
+++ b/Spaceman/Model/SpaceNameInfo.swift
@@ -11,4 +11,6 @@ struct SpaceNameInfo: Hashable, Codable {
     let spaceNum: Int
     let spaceName: String
     let spaceByDesktopID: String
+    // Current display index after applying user display ordering (1..D). Optional for backward compatibility.
+    var currentDisplayIndex: Int? = nil
 }

--- a/Spaceman/Utilities/Constants.swift
+++ b/Spaceman/Utilities/Constants.swift
@@ -22,9 +22,20 @@ struct Constants {
     //   7.5 =  90 px ; void left
 
     static let sizes: [LayoutMode: GuiSize] = [
+        .dualRows: GuiSize(
+            GAP_WIDTH_SPACES: 3,
+            GAP_WIDTH_DISPLAYS: 8,
+            GAP_HEIGHT_DUALROWS: 3,
+            ICON_WIDTH_SMALL: 16,
+            ICON_WIDTH_LARGE: 24,
+            ICON_WIDTH_XLARGE: 36,
+            ICON_HEIGHT: 10,
+            FONT_SIZE: 9
+        ),
         .compact: GuiSize(
             GAP_WIDTH_SPACES: 3,
             GAP_WIDTH_DISPLAYS: 8,
+            GAP_HEIGHT_DUALROWS: 0,
             ICON_WIDTH_SMALL: 16,
             ICON_WIDTH_LARGE: 24,
             ICON_WIDTH_XLARGE: 36,
@@ -34,6 +45,7 @@ struct Constants {
         .medium: GuiSize(
             GAP_WIDTH_SPACES: 5,
             GAP_WIDTH_DISPLAYS: 12,
+            GAP_HEIGHT_DUALROWS: 0,
             ICON_WIDTH_SMALL: 18,
             ICON_WIDTH_LARGE: 32,
             ICON_WIDTH_XLARGE: 42,
@@ -43,6 +55,7 @@ struct Constants {
         .large: GuiSize(
             GAP_WIDTH_SPACES: 5,
             GAP_WIDTH_DISPLAYS: 14,
+            GAP_HEIGHT_DUALROWS: 0,
             ICON_WIDTH_SMALL: 20,
             ICON_WIDTH_LARGE: 34,
             ICON_WIDTH_XLARGE: 49,

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -22,6 +22,7 @@ struct PreferencesView: View {
     @AppStorage("displayOrderPriority") private var displayOrderPriority = DisplayOrderPriority.horizontal
     @AppStorage("horizontalDirection") private var horizontalDirection = HorizontalDirection.leftToRight
     @AppStorage("verticalDirection") private var verticalDirection = VerticalDirection.topToBottom
+    @AppStorage("dualRowFillOrder") private var dualRowFillOrder = DualRowFillOrder.columnMajor
     @AppStorage("schema") private var keySet = KeySet.toprow
     @AppStorage("withShift") private var withShift = false
     @AppStorage("withControl") private var withControl = false
@@ -138,6 +139,19 @@ struct PreferencesView: View {
             Toggle("Refresh spaces in background", isOn: $autoRefreshSpaces)
             shortcutRecorder.disabled(autoRefreshSpaces)
             layoutSizePicker
+            HStack(spacing: 12) {
+                Text("Fill order")
+                    .foregroundColor(layoutMode == .dualRows ? .primary : .secondary)
+                Spacer()
+                Picker("", selection: $dualRowFillOrder) {
+                    Text("Row first").tag(DualRowFillOrder.rowMajor)
+                    Text("Column first").tag(DualRowFillOrder.columnMajor)
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+                .fixedSize()
+            }
+            .disabled(layoutMode != .dualRows)
         }
         .padding()
         .onChange(of: autoRefreshSpaces) { enabled in
@@ -149,6 +163,9 @@ struct PreferencesView: View {
                 prefsVM.pauseTimer()
                 KeyboardShortcuts.enable(.refresh)
             }
+        }
+        .onChange(of: dualRowFillOrder) { _ in
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "ButtonPressed"), object: nil)
         }
     }
 

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -284,10 +284,12 @@ struct PreferencesView: View {
             Picker(selection: $prefsVM.selectedSpace, label: Text("Space")) {
                 ForEach(0..<prefsVM.sortedSpaceNamesDict.count, id: \.self) { index in
                     let info = prefsVM.sortedSpaceNamesDict[index].value
-                                        let sbd = info.spaceByDesktopID
+                    let sbd = info.spaceByDesktopID
                     let displayIndex = info.currentDisplayIndex ?? 1
                     let spacePart: String = (sbd.hasPrefix("F") ? ("Full Screen "+String(Int(sbd.dropFirst()) ?? 0)) : "Space \(sbd)")
-                    Text("Display \(displayIndex): \(spacePart)")
+                    let hasMultipleDisplays = NSScreen.screens.count > 1
+                    let label = hasMultipleDisplays ? "Display \(displayIndex): \(spacePart)" : spacePart
+                    Text(label)
                 }
             }
             .layoutPriority(3)

--- a/Spaceman/View/PreferencesWindow.swift
+++ b/Spaceman/View/PreferencesWindow.swift
@@ -11,7 +11,7 @@ import AppKit
 class PreferencesWindow: NSWindow {
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 330),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 710),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/Spaceman/View/PreferencesWindow.swift
+++ b/Spaceman/View/PreferencesWindow.swift
@@ -11,7 +11,7 @@ import AppKit
 class PreferencesWindow: NSWindow {
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 710),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 680),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/Spaceman/View/PreferencesWindow.swift
+++ b/Spaceman/View/PreferencesWindow.swift
@@ -11,7 +11,7 @@ import AppKit
 class PreferencesWindow: NSWindow {
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 680),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 710),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/Spaceman/View/StatusBar.swift
+++ b/Spaceman/View/StatusBar.swift
@@ -97,10 +97,12 @@ class StatusBar: NSObject, NSMenuDelegate {
                     print("Not switching: just one space visible")
                     return
                 }
-                let locationInButton = sbButton.convert(event.locationInWindow, from: sbButton)
+                let locationInButton = sbButton.convert(event.locationInWindow, from: nil)
+                // Convert to bottom-origin coordinates for hit testing
+                let adjPoint = NSPoint(x: locationInButton.x, y: sbButton.bounds.height - locationInButton.y)
                 self.spaceSwitcher.switchUsingLocation(
                     iconWidths: self.iconCreator.iconWidths,
-                    horizontal: locationInButton.x,
+                    point: adjPoint,
                     onError: self.flashStatusBar)
             } else {
                 print("Other event: \(event.type)")

--- a/Spaceman/ViewModel/PreferencesViewModel.swift
+++ b/Spaceman/ViewModel/PreferencesViewModel.swift
@@ -40,7 +40,9 @@ class PreferencesViewModel: ObservableObject {
         }
         
         let sorted = spaceNamesDict.sorted { (first, second) -> Bool in
-            return first.value.spaceNum < second.value.spaceNum
+            let a = first.value.currentOrder ?? first.value.spaceNum
+            let b = second.value.currentOrder ?? second.value.spaceNum
+            return a < b
         }
         sortedSpaceNamesDict = sorted
         if sortedSpaceNamesDict.isEmpty {


### PR DESCRIPTION
1. Added a "Displays" section with configuration options, allowing users to set ordering rules to determine display sequence when multiple displays are connected. This enhances the original horizontal-axis-only comparison method by supporting both horizontal and vertical axis prioritization with configurable sorting directions. This ensures more precise and stable display arrangement when switching between different external displays on a MacBook.

<img width="390" height="139" alt="截屏2025-09-14 01 14 36" src="https://github.com/user-attachments/assets/87ec50f2-2169-43c7-ab7c-75578670f837" />

2. Introduced a "Dual Rows" layout where status icons in the system menu bar are displayed in two rows, significantly improving space efficiency in the status bar area.

<img width="394" height="40" alt="截屏2025-09-14 01 14 45" src="https://github.com/user-attachments/assets/4d6273e2-1d31-4464-b8b4-34889d97fb0f" />


<img width="169" height="33" alt="截屏2025-09-14 01 18 43" src="https://github.com/user-attachments/assets/7d76edab-e185-4c47-a836-06eaa6072e94" />


3. The space naming dropdown menu now displays more detailed Display and Space/Full Screen identifiers, providing users with clearer reference information when naming spaces during display ordering rule changes.

<img width="391" height="218" alt="截屏2025-09-14 01 15 00" src="https://github.com/user-attachments/assets/37be0250-bc2d-4281-a1d3-c50678cb254b" />

4. Added visual separators between Spaces from different displays in the right-click context menu, making it easier for users to visually distinguish between them.

<img width="223" height="358" alt="截屏2025-09-14 01 15 41" src="https://github.com/user-attachments/assets/c39472ca-2fda-43c5-add6-3d1ee13a5df1" />
